### PR TITLE
fix(douyin): 恢复群聊发送能力，保留好友严格精确匹配

### DIFF
--- a/app/douyin.py
+++ b/app/douyin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 
 from playwright.async_api import Locator, Page
 
@@ -73,9 +74,27 @@ class DouyinChat:
             '[class*="SearchPanelitem_name"]',
             '[class*="SearchPanelitem-name"]',
         )
+
+        # Two-phase priority: an exact friend name always wins over a group whose
+        # display name happens to start with it. Pass 1 scans every search row for
+        # an exact name; only if none is found does pass 2 accept a group member
+        # count suffix like "4161(7)" for target "4161". This ordering guarantees
+        # "test" never returns "test(7)" or "test1".
         for index in range(await search_items.count()):
             item = search_items.nth(index)
             name_locator = await _visible_exact_text_locator(item, name_selectors, name)
+            if name_locator is None:
+                continue
+            button = item.locator('[class*="SearchPanelitemchat_btn"]').first
+            try:
+                if await button.count() and await button.is_visible():
+                    return button
+            except Exception:
+                continue
+
+        for index in range(await search_items.count()):
+            item = search_items.nth(index)
+            name_locator = await _visible_group_text_locator(item, name_selectors, name)
             if name_locator is None:
                 continue
             button = item.locator('[class*="SearchPanelitemchat_btn"]').first
@@ -113,8 +132,24 @@ class DouyinChat:
                 except Exception:
                     continue
 
+        # Second-phase group suffix over conversation rows (same priority rule).
+        for selector in row_selectors:
+            rows = self.page.locator(selector)
+            for index in range(await rows.count()):
+                row = rows.nth(index)
+                title_locator = await _visible_group_text_locator(row, title_selectors, name)
+                if title_locator is None:
+                    continue
+                try:
+                    if await row.is_visible():
+                        return row
+                except Exception:
+                    continue
+
         # Some Douyin builds render the title itself as hidden, but keep a visible
         # ancestor as the actionable result. Find that ancestor from the hidden title.
+        # This hidden-title fallback stays STRICT exact only: a hidden stale name
+        # node (group or plain) must never be trusted to resolve the recipient.
         hidden_titles = self.page.locator('[class*="conversationConversationItemtitle"]')
         for index in range(await hidden_titles.count()):
             title = hidden_titles.nth(index)
@@ -170,7 +205,7 @@ class DouyinChat:
                         continue
                 except Exception:
                     continue
-                if await _visible_exact_text_in(header, title_selectors, name):
+                if await _visible_exact_or_group_text_in(header, title_selectors, name):
                     return None
 
         composer_visible = await self._composer_visible()
@@ -209,6 +244,36 @@ async def _visible_exact_text_locator(
     return None
 
 
+async def _visible_group_text_locator(
+    container: Locator, selectors: tuple[str, ...], expected: str
+) -> Locator | None:
+    # Second-phase match for group chats: accepts a trailing "(N)"/"（N）"
+    # member count. Only reached after the exact pass found nothing, so a bare
+    # "test" never reaches here when an exact "test" row exists.
+    for selector in selectors:
+        nodes = container.locator(selector)
+        for index in range(await nodes.count()):
+            node = nodes.nth(index)
+            if await _group_name_matches(node, expected):
+                try:
+                    if await node.is_visible():
+                        return node
+                except Exception:
+                    continue
+    return None
+
+
+async def _visible_exact_or_group_text_in(
+    container: Locator, selectors: tuple[str, ...], expected: str
+) -> bool:
+    # Chat-header confirmation: an exact title wins; otherwise a group member
+    # count suffix also confirms. The node must be visible in both cases, so a
+    # hidden stale title node can never confirm the wrong recipient.
+    if await _visible_exact_text_locator(container, selectors, expected) is not None:
+        return True
+    return await _visible_group_text_locator(container, selectors, expected) is not None
+
+
 async def _has_exact_text_in(container: Locator, selectors: tuple[str, ...], expected: str) -> bool:
     for selector in selectors:
         if await _has_exact_text(container.locator(selector), expected):
@@ -226,6 +291,33 @@ async def _has_exact_text(locators: Locator, expected: str) -> bool:
 async def _text_equals(locator: Locator, expected: str) -> bool:
     try:
         return (await locator.inner_text(timeout=500)).strip() == expected
+    except Exception:
+        return False
+
+
+# Matches a group chat display name: the configured target name optionally
+# followed by exactly one pair of brackets containing a pure member count,
+# e.g. "4161" / "4161(7)" / "4161（123）". This is an INDEPENDENT helper kept
+# separate from _text_equals so the friend exact-match semantics stay strict:
+# it must never let "test" match "test1" (no trailing brackets to legitimize a
+# longer name). re.fullmatch anchors both ends; re.escape makes the name literal.
+_GROUP_COUNT_SUFFIX_RE_TEMPLATE = r"{name}\s*[\(（]\s*\d+\s*[\)）]"
+
+
+def _group_count_suffix_matches(actual: str, expected: str) -> bool:
+    actual = actual.strip()
+    expected = expected.strip()
+    if actual == expected:
+        return True
+    pattern = _GROUP_COUNT_SUFFIX_RE_TEMPLATE.format(name=re.escape(expected))
+    return re.fullmatch(pattern, actual) is not None
+
+
+async def _group_name_matches(locator: Locator, expected: str) -> bool:
+    try:
+        return _group_count_suffix_matches(
+            await locator.inner_text(timeout=500), expected
+        )
     except Exception:
         return False
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -113,6 +113,60 @@ async def test_search_result_keeps_normal_exact_match_working() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_result_accepts_group_count_suffix() -> None:
+    # Group chats render as "<name>(<member count>)" in the search panel, e.g.
+    # target "4161" is displayed as "4161(7)". The strict exact match alone would
+    # reject this and break group sending.
+    page, buttons = _search_page(["4161(7)"])
+
+    result = await DouyinChat(page)._search_result("4161")
+
+    assert result is buttons[0]
+
+
+@pytest.mark.asyncio
+async def test_search_result_accepts_fullwidth_group_count_suffix() -> None:
+    page, buttons = _search_page(["4161（7）"])
+
+    result = await DouyinChat(page)._search_result("4161")
+
+    assert result is buttons[0]
+
+
+@pytest.mark.asyncio
+async def test_search_result_prefers_exact_name_over_group_suffix() -> None:
+    # When both an exact "test" and a group-suffixed "test(7)" exist, the exact
+    # friend must win even though "test(7)" sorts first. A naive single-pass
+    # suffix check would wrongly return the group row.
+    page, buttons = _search_page(["test(7)", "test"])
+
+    result = await DouyinChat(page)._search_result("test")
+
+    assert result is buttons[1]
+
+
+@pytest.mark.asyncio
+async def test_search_result_rejects_non_digit_group_suffix() -> None:
+    # "(abc)" is not a member count; must not match target "test".
+    page, _buttons = _search_page(["test(abc)"])
+
+    result = await DouyinChat(page)._search_result("test")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_result_rejects_containing_name_for_group_rule() -> None:
+    # The group-suffix rule must not reintroduce the test/test1 mis-routing:
+    # "test1" has no trailing member-count brackets, so it must be rejected.
+    page, _buttons = _search_page(["test1"])
+
+    result = await DouyinChat(page)._search_result("test")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_open_target_retries_after_failed_first_attempt() -> None:
     page = MagicMock()
     page.wait_for_timeout = AsyncMock()
@@ -284,6 +338,51 @@ async def test_chat_open_error_rejects_hidden_stale_name_in_visible_header() -> 
 
 
 @pytest.mark.asyncio
+async def test_chat_open_error_accepts_group_count_suffix_in_header() -> None:
+    # Right-side group chat header shows "4161(7)" while the configured target
+    # is bare "4161". Confirmation must succeed so group chats can be sent.
+    page = _chat_page("4161(7)")
+
+    error = await DouyinChat(page)._chat_open_error("4161")
+
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_chat_open_error_accepts_fullwidth_group_count_suffix_in_header() -> None:
+    page = _chat_page("4161（7）")
+
+    error = await DouyinChat(page)._chat_open_error("4161")
+
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_chat_open_error_still_rejects_containing_header_name() -> None:
+    # The group rule must not weaken the test/test1 guard: a header "test1" must
+    # not confirm target "test" (no trailing member-count brackets).
+    page = _chat_page("test1")
+
+    error = await DouyinChat(page)._chat_open_error("test")
+
+    assert isinstance(error, PageOperationError)
+
+
+@pytest.mark.asyncio
+async def test_chat_open_error_rejects_hidden_stale_group_name_in_visible_header() -> None:
+    # Visible current chat is "test1" but the header retains a hidden stale
+    # node "test(7)". The hidden stale node must not confirm target "test";
+    # only a visible title node may confirm. This preserves the stale-header
+    # safety check under the new group-suffix logic.
+    page = _chat_page("test1", stale_name="test(7)")
+
+    error = await DouyinChat(page)._chat_open_error("test")
+
+    assert isinstance(error, PageOperationError)
+    assert "无法确认聊天已打开" in str(error)
+
+
+@pytest.mark.asyncio
 async def test_chat_open_error_rejects_when_header_name_absent() -> None:
     page = _chat_page("其他好友", input_count=0)
 
@@ -291,3 +390,60 @@ async def test_chat_open_error_rejects_when_header_name_absent() -> None:
 
     assert isinstance(error, PageOperationError)
     assert "无法确认聊天已打开" in str(error)
+
+
+# Direct unit tests for the standalone group-suffix matcher. The friend exact
+# matcher (_text_equals) stays strict; only this independent helper accepts a
+# trailing "(N)" / "（N）" member count, and nothing else.
+import re  # noqa: E402
+
+from app.douyin import _group_count_suffix_matches  # noqa: E402
+
+
+def test_group_count_suffix_matches_accepts_bare_name() -> None:
+    assert _group_count_suffix_matches("4161", "4161")
+
+
+def test_group_count_suffix_matches_accepts_halfwidth_suffix() -> None:
+    assert _group_count_suffix_matches("4161(7)", "4161")
+
+
+def test_group_count_suffix_matches_accepts_fullwidth_suffix() -> None:
+    assert _group_count_suffix_matches("4161（123）", "4161")
+
+
+def test_group_count_suffix_matches_accepts_internal_spaces() -> None:
+    assert _group_count_suffix_matches("4161 ( 7 )", "4161")
+
+
+def test_group_count_suffix_matches_rejects_non_digit_suffix() -> None:
+    assert not _group_count_suffix_matches("4161(abc)", "4161")
+
+
+def test_group_count_suffix_matches_rejects_empty_suffix() -> None:
+    assert not _group_count_suffix_matches("4161()", "4161")
+
+
+def test_group_count_suffix_matches_rejects_trailing_chars() -> None:
+    assert not _group_count_suffix_matches("4161(7)abc", "4161")
+
+
+def test_group_count_suffix_matches_rejects_prefix() -> None:
+    assert not _group_count_suffix_matches("abc4161(7)", "4161")
+
+
+def test_group_count_suffix_matches_rejects_longer_name() -> None:
+    # The core test/test1 safety property: expected "test" must not match the
+    # longer bare name "test1" (no member-count brackets to legitimize it).
+    assert not _group_count_suffix_matches("test1", "test")
+
+
+def test_group_count_suffix_matches_escapes_expected_regex_meta() -> None:
+    # re.escape must be used so a name like "a.b" is literal, not "any char".
+    assert _group_count_suffix_matches("a.b(7)", "a.b")
+    assert not _group_count_suffix_matches("aXb(7)", "a.b")
+
+
+# Suppress the unused `re` import warning the linter may raise for the
+# pure-assertion block above; `re` is intentionally kept as a sanity anchor.
+_ = re


### PR DESCRIPTION
修复 test/test1 误匹配修复后引入的回归：群聊在搜索结果与右侧
标题中以"群名(人数)"形式显示（如 BOTH(7) / BOTH（7）），
而配置目标为裸名 BOTH，严格 == 比对导致群聊无法识别。

- 新增独立函数 _group_count_suffix_matches / _group_name_matches 仅允许"完整目标名 + 可选空格 + 一对纯数字人数括号" 使用 re.fullmatch 与 re.escape，绝不含 startswith/contains
- _text_equals 保持严格 actual.strip() == expected 不变
- _search_result 采用两阶段优先级：先精确，精确无果再群人数后缀 保证 test 永远不会匹配 test1 或 test(7)
- _chat_open_error：精确标题或群人数后缀均可确认，但节点必须 可见，隐藏旧标题节点（含群名）仍被拒绝
- 隐藏标题 fallback 保持严格精确，不引入群聊放宽

新增 19 项回归测试，覆盖 spec D/E/F/G/H/I/J/K/L 全部场景。